### PR TITLE
change tls to use lax tls version and legacy ciphers

### DIFF
--- a/hackterm-core/hackterm_core/proxy.py
+++ b/hackterm-core/hackterm_core/proxy.py
@@ -92,6 +92,8 @@ class ProxyDaemon:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if self.use_tls:
             ctx = ssl._create_unverified_context()
+            ctx.minimum_version = ssl.TLSVersion.TLSv1
+            ctx.set_ciphers("DEFAULT@SECLEVEL=0")
             sock = ctx.wrap_socket(sock, server_hostname=self.target_addr[0])
         sock.connect(self.target_addr)
         self.server = sock


### PR DESCRIPTION
I was having connection issues with the TLS handshake being rejected by version/cipher mismatches. 

`connect_to_server` builds the context with `ssl._create_unverified_context()`, disabling cert verification but it will inherit OpenSSL 3.x defaults: TLS 1.2 minimum + SECLEVEL=2. 
SECLEVEL 2 disables SHA-1 ciphers, RSA key exchange, and 3DES

Allowing the downgrade shouldn't be an issue but will allow connections to mainframes with old TLS and sad old ciphers. Happy to gate this behind a `--lax-tls` flag if you'd rather keep the strict context as the default, just let me know and I'll add the toggle.